### PR TITLE
Issue and PR templates links to point to PCBox instead of 86Box

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -37,15 +37,15 @@ body:
       required: true
   - type: input
     attributes:
-      label: 86Box version
-      description: What version of 86Box are you running? (Saying "Latest from Jenkins" is not helpful.)
+      label: PCBox version
+      description: What version of PCBox are you running? (Saying "Latest from Jenkins" is not helpful.)
       placeholder: e.g. v4.0 build 5000
     validations:
       required: true
   - type: dropdown
     attributes:
       label: Build architecture
-      description: 86Box for what architecture are you using?
+      description: PCBox for what architecture are you using?
       options: 
         - Linux - ARM (32-bit) 
         - Linux - ARM (64-bit) 
@@ -66,12 +66,12 @@ body:
   - type: dropdown
     attributes:
       label: Download source
-      description: Where did you download 86Box from?
+      description: Where did you download PCBox from?
       options:
         - Official website (Jenkins, GitHub)
         - Manager auto-update
-        - I built 86Box myself (please tell us more about your build configuration)
-        - I got 86Box from a third party repository (please tell us where)
+        - I built PCBox myself (please tell us more about your build configuration)
+        - I got PCBox from a third party repository (please tell us where)
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url:  https://github.com/86Box/86Box/issues/3577#issue-comment-box
     about: Please submit machine addition requests under this tracking issue.
   - name: Feature Request or Question
-    url:  https://github.com/86Box/86Box/discussions
+    url:  https://github.com/PCBox/PCBox/discussions
     about: Please submit feature requests and ask questions here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@ Checklist
 * [ ] Closes #xxx
 * [ ] I have discussed this with core contributors already
 * [ ] This pull request requires changes to the ROM set
-  * [ ] I have opened a roms pull request - https://github.com/86Box/roms/pull/changeme/
+  * [ ] I have opened a roms pull request - https://github.com/PCBox/roms/pull/changeme/
 
 References
 ==========


### PR DESCRIPTION
New Issue and PR templates had links to 86Box repository. Changed most of those.

Pending:
- Machine request points to 86Box issue 3577, but I don't see PCBox equivalent
- PR at 86Box goes to broken link https://github.com/86Box/roms/pull/changeme/ - updated that to the same with "PCBox" inside, but still "changeme" probably means that has to be further updated?