### PR TITLE
Update PCBox.spec - Added Year to changelog to fix automated builds

### DIFF
--- a/src/unix/assets/PCBox.spec
+++ b/src/unix/assets/PCBox.spec
@@ -125,6 +125,5 @@ popd
 %{_datadir}/%{name}/roms
 
 %changelog
-
-* Sun Sep 15 Britney Lozza <bnlozza[AT]gmail.com> 4.2.4
+* Sun Sep 15 2024 Britney Lozza <bnlozza@gmail.com> - 4.2.4-2
 - Fixing fuel's bad forking by porting the spec file from 86Box to PCBox


### PR DESCRIPTION
Summary
=======
Sorry, it build but gave me a warning about the bad format of the changelog. I added the year so that automated builds don't fail on COPR.

Checklist
=========
* [ ] Adds 2024

References
==========
RPM build warnings:
stderr: error: bad date in %changelog: Sun Sep 15 Britney Lozza <bnlozza[AT]gmail.com> 4.2.4
error: bad date in %changelog: Sun Sep 15 Britney Lozza <bnlozza[AT]gmail.com> 4.2.4
warning: source_date_epoch_from_changelog set but %changelog is missing

https://www.spinics.net/lists/fedora-devel/msg307358.html