### PR TITLE
Fix: buffer overflow when dumping XMM registers in gdbstub

### DIFF
--- a/src/gdbstub.c
+++ b/src/gdbstub.c
@@ -825,7 +825,7 @@ gdbstub_client_packet(gdbstub_client_t *client)
     int     j = 0;
     int     k = 0;
     int     l;
-    uint8_t buf[10] = { 0 };
+    uint8_t buf[16] = { 0 };
     char   *p;
 
     /* Validate checksum. */
@@ -1508,7 +1508,7 @@ gdbstub_cpu_exec(int32_t cycs)
         }
 
         /* Add register dump. */
-        uint8_t buf[10] = { 0 };
+        uint8_t buf[16] = { 0 };
         int     j;
         for (int i = 0; i < GDB_REG_MAX; i++) {
             if (i >= 0x10)


### PR DESCRIPTION
Summary
=======
- **FIX:** gdbstub was crashing due to a stack buffer overflow when dumping SSE/SSE2 registers
  - The buffer used to hold the register contents was only 10 bytes long, while the XMM registers are 16 bytes long.

Checklist
=========
* [ ] Closes #xxx
* [x] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/PCBox/roms/pull/changeme/

References
==========
N/A
