### PR TITLE
codegen_new: JIT-compile IMUL and XADD instructions natively

### DIFF
--- a/src/codegen_new/codegen_backend_arm64_ops.c
+++ b/src/codegen_new/codegen_backend_arm64_ops.c
@@ -176,6 +176,7 @@
 #    define OPCODE_LSR                (0x1ac02400)
 #    define OPCODE_MSR_FPCR           (0xd51b4400)
 #    define OPCODE_MUL_V4H            (0x0e609c00)
+#    define OPCODE_MUL                (0x1b007c00)
 #    define OPCODE_NOP                (0xd503201f)
 #    define OPCODE_ORR_V              (0x0ea01c00)
 #    define OPCODE_RET                (0xd65f0000)
@@ -1253,6 +1254,12 @@ void
 host_arm64_MUL_V4H(codeblock_t *block, int dst_reg, int src_n_reg, int src_m_reg)
 {
     codegen_addlong(block, OPCODE_MUL_V4H | Rd(dst_reg) | Rn(src_n_reg) | Rm(src_m_reg));
+}
+
+void
+host_arm64_MUL(codeblock_t *block, int dst_reg, int src_n_reg, int src_m_reg)
+{
+    codegen_addlong(block, OPCODE_MUL | Rd(dst_reg) | Rn(src_n_reg) | Rm(src_m_reg));
 }
 
 void

--- a/src/codegen_new/codegen_backend_arm64_ops.h
+++ b/src/codegen_new/codegen_backend_arm64_ops.h
@@ -94,6 +94,7 @@ void host_arm64_FMAX_V2S(codeblock_t *block, int dst_reg, int src_n_reg, int src
 void host_arm64_FMIN_V2S(codeblock_t *block, int dst_reg, int src_n_reg, int src_m_reg);
 void host_arm64_FMUL_D(codeblock_t *block, int dst_reg, int src_n_reg, int src_m_reg);
 void host_arm64_FMUL_V2S(codeblock_t *block, int dst_reg, int src_n_reg, int src_m_reg);
+void host_arm64_MUL(codeblock_t *block, int dst_reg, int src_n_reg, int src_m_reg);
 void host_arm64_FSUB_D(codeblock_t *block, int dst_reg, int src_n_reg, int src_m_reg);
 void host_arm64_FSUB_V2S(codeblock_t *block, int dst_reg, int src_n_reg, int src_m_reg);
 

--- a/src/codegen_new/codegen_backend_arm64_uops.c
+++ b/src/codegen_new/codegen_backend_arm64_uops.c
@@ -98,6 +98,64 @@ codegen_ADD_LSHIFT(codeblock_t *block, uop_t *uop)
 }
 
 static int
+codegen_IMUL(codeblock_t *block, uop_t *uop)
+{
+    int dest_reg   = HOST_REG_GET(uop->dest_reg_a_real);
+    int src_reg_a  = HOST_REG_GET(uop->src_reg_a_real);
+    int src_reg_b  = HOST_REG_GET(uop->src_reg_b_real);
+    int dest_size  = IREG_GET_SIZE(uop->dest_reg_a_real);
+    int src_size_a = IREG_GET_SIZE(uop->src_reg_a_real);
+    int src_size_b = IREG_GET_SIZE(uop->src_reg_b_real);
+
+    if (REG_IS_L(dest_size) && REG_IS_L(src_size_a) && REG_IS_L(src_size_b)) {
+        host_arm64_MUL(block, dest_reg, src_reg_a, src_reg_b);
+    } else if (REG_IS_W(dest_size) && REG_IS_W(src_size_a) && REG_IS_W(src_size_b)) {
+        host_arm64_MUL(block, REG_TEMP, src_reg_a, src_reg_b);
+        host_arm64_BFI(block, dest_reg, REG_TEMP, 0, 16);
+    }
+#    ifdef RECOMPILER_DEBUG
+    else
+        fatal("IMUL size mismatch: dest_size=%x, src_size_a=%x, src_size_b=%x\n", dest_size, src_size_a, src_size_b);
+#    endif
+    return 0;
+}
+
+static int
+codegen_IMUL_IMM(codeblock_t *block, uop_t *uop)
+{
+    int dest_reg  = HOST_REG_GET(uop->dest_reg_a_real);
+    int src_reg   = HOST_REG_GET(uop->src_reg_a_real);
+    int dest_size = IREG_GET_SIZE(uop->dest_reg_a_real);
+    int src_size  = IREG_GET_SIZE(uop->src_reg_a_real);
+
+    if (REG_IS_L(dest_size) && REG_IS_L(src_size)) {
+        uint32_t imm = uop->imm_data;
+        if (imm <= 0xffff) {
+            host_arm64_MOVZ_IMM(block, REG_W16, imm);
+        } else {
+            host_arm64_MOVZ_IMM(block, REG_W16, imm & 0xffff);
+            host_arm64_MOVK_IMM(block, REG_W16, imm & 0xffff0000);
+        }
+        host_arm64_MUL(block, dest_reg, src_reg, REG_W16);
+    } else if (REG_IS_W(dest_size) && REG_IS_W(src_size)) {
+        uint32_t imm = uop->imm_data;
+        if (imm <= 0xffff) {
+            host_arm64_MOVZ_IMM(block, REG_W16, imm);
+        } else {
+            host_arm64_MOVZ_IMM(block, REG_W16, imm & 0xffff);
+            host_arm64_MOVK_IMM(block, REG_W16, imm & 0xffff0000);
+        }
+        host_arm64_MUL(block, REG_TEMP, src_reg, REG_W16);
+        host_arm64_BFI(block, dest_reg, REG_TEMP, 0, 16);
+    }
+#    ifdef RECOMPILER_DEBUG
+    else
+        fatal("IMUL_IMM size mismatch: dest_size=%x, src_size=%x\n", dest_size, src_size);
+#    endif
+    return 0;
+}
+
+static int
 codegen_AND(codeblock_t *block, uop_t *uop)
 {
     int dest_reg   = HOST_REG_GET(uop->dest_reg_a_real);
@@ -214,6 +272,7 @@ codegen_CALL_FUNC_RESULT(codeblock_t *block, uop_t *uop)
 
     return 0;
 }
+
 
 static int
 codegen_CALL_INSTRUCTION_FUNC(codeblock_t *block, uop_t *uop)
@@ -3235,6 +3294,12 @@ const uOpFn uop_handlers[UOP_MAX] = {
     [UOP_ADD_IMM &
         UOP_MASK]
     = codegen_ADD_IMM,
+    [UOP_IMUL &
+        UOP_MASK]
+    = codegen_IMUL,
+    [UOP_IMUL_IMM &
+        UOP_MASK]
+    = codegen_IMUL_IMM,
     [UOP_ADD_LSHIFT &
         UOP_MASK]
     = codegen_ADD_LSHIFT,

--- a/src/codegen_new/codegen_backend_x86-64_ops.c
+++ b/src/codegen_new/codegen_backend_x86-64_ops.c
@@ -2010,7 +2010,7 @@ host_x86_IMUL16_REG_REG(codeblock_t *block, int dst_reg, int src_reg)
 #endif
 
     codegen_alloc_bytes(block, 4);
-    codegen_addbyte4(block, 0x66, 0x0f, 0xaf, 0xc0 | ((dst_reg & 7) << 3) | (src_reg & 7));
+    codegen_addbyte4(block, 0x66, 0x0f, 0xaf, 0xc0 | ((dst_reg & 7) << 3) | (src_reg & 7)); /*imul dst_reg, src_reg*/
 }
 
 void
@@ -2022,7 +2022,7 @@ host_x86_IMUL32_REG_REG(codeblock_t *block, int dst_reg, int src_reg)
 #endif
 
     codegen_alloc_bytes(block, 3);
-    codegen_addbyte3(block, 0x0f, 0xaf, 0xc0 | ((dst_reg & 7) << 3) | (src_reg & 7));
+    codegen_addbyte3(block, 0x0f, 0xaf, 0xc0 | ((dst_reg & 7) << 3) | (src_reg & 7)); /*imul dst_reg, src_reg*/
 }
 
 void
@@ -2035,10 +2035,10 @@ host_x86_IMUL16_REG_IMM(codeblock_t *block, int dst_reg, int src_reg, int16_t im
 
     if (imm >= -128 && imm <= 127) {
         codegen_alloc_bytes(block, 4);
-        codegen_addbyte4(block, 0x66, 0x6b, 0xc0 | ((dst_reg & 7) << 3) | (src_reg & 7), (uint8_t)imm);
+        codegen_addbyte4(block, 0x66, 0x6b, 0xc0 | ((dst_reg & 7) << 3) | (src_reg & 7), (uint8_t)imm); /*imul dst_reg, src_reg, imm*/
     } else {
         codegen_alloc_bytes(block, 5);
-        codegen_addbyte3(block, 0x66, 0x69, 0xc0 | ((dst_reg & 7) << 3) | (src_reg & 7));
+        codegen_addbyte3(block, 0x66, 0x69, 0xc0 | ((dst_reg & 7) << 3) | (src_reg & 7)); /*imul dst_reg, src_reg, imm*/
         codegen_addbyte2(block, (uint8_t)imm, (uint8_t)(imm >> 8));
     }
 }
@@ -2053,10 +2053,10 @@ host_x86_IMUL32_REG_IMM(codeblock_t *block, int dst_reg, int src_reg, int32_t im
 
     if (imm >= -128 && imm <= 127) {
         codegen_alloc_bytes(block, 3);
-        codegen_addbyte3(block, 0x6b, 0xc0 | ((dst_reg & 7) << 3) | (src_reg & 7), (uint8_t)imm);
+        codegen_addbyte3(block, 0x6b, 0xc0 | ((dst_reg & 7) << 3) | (src_reg & 7), (uint8_t)imm); /*imul dst_reg, src_reg, imm*/
     } else {
         codegen_alloc_bytes(block, 6);
-        codegen_addbyte2(block, 0x69, 0xc0 | ((dst_reg & 7) << 3) | (src_reg & 7));
+        codegen_addbyte2(block, 0x69, 0xc0 | ((dst_reg & 7) << 3) | (src_reg & 7)); /*imul dst_reg, src_reg, imm*/
         codegen_addlong(block, imm);
     }
 }

--- a/src/codegen_new/codegen_backend_x86-64_ops.c
+++ b/src/codegen_new/codegen_backend_x86-64_ops.c
@@ -2001,4 +2001,65 @@ host_x86_XOR32_REG_REG(codeblock_t *block, int dst_reg, int src_reg)
     codegen_addbyte2(block, 0x31, 0xc0 | (dst_reg & 7) | ((src_reg & 7) << 3)); /*XOR dst_reg, src_reg*/
 }
 
+void
+host_x86_IMUL16_REG_REG(codeblock_t *block, int dst_reg, int src_reg)
+{
+#ifdef RECOMPILER_DEBUG
+    if ((dst_reg & 8) || (src_reg & 8))
+        fatal("host_x86_IMUL16_REG_REG - dst_reg & 8\n");
 #endif
+
+    codegen_alloc_bytes(block, 4);
+    codegen_addbyte4(block, 0x66, 0x0f, 0xaf, 0xc0 | ((dst_reg & 7) << 3) | (src_reg & 7));
+}
+
+void
+host_x86_IMUL32_REG_REG(codeblock_t *block, int dst_reg, int src_reg)
+{
+#ifdef RECOMPILER_DEBUG
+    if ((dst_reg & 8) || (src_reg & 8))
+        fatal("host_x86_IMUL32_REG_REG - dst_reg & 8\n");
+#endif
+
+    codegen_alloc_bytes(block, 3);
+    codegen_addbyte3(block, 0x0f, 0xaf, 0xc0 | ((dst_reg & 7) << 3) | (src_reg & 7));
+}
+
+void
+host_x86_IMUL16_REG_IMM(codeblock_t *block, int dst_reg, int src_reg, int16_t imm)
+{
+#ifdef RECOMPILER_DEBUG
+    if ((dst_reg & 8) || (src_reg & 8))
+        fatal("host_x86_IMUL16_REG_IMM - dst_reg & 8\n");
+#endif
+
+    if (imm >= -128 && imm <= 127) {
+        codegen_alloc_bytes(block, 4);
+        codegen_addbyte4(block, 0x66, 0x6b, 0xc0 | ((dst_reg & 7) << 3) | (src_reg & 7), (uint8_t)imm);
+    } else {
+        codegen_alloc_bytes(block, 5);
+        codegen_addbyte3(block, 0x66, 0x69, 0xc0 | ((dst_reg & 7) << 3) | (src_reg & 7));
+        codegen_addbyte2(block, (uint8_t)imm, (uint8_t)(imm >> 8));
+    }
+}
+
+void
+host_x86_IMUL32_REG_IMM(codeblock_t *block, int dst_reg, int src_reg, int32_t imm)
+{
+#ifdef RECOMPILER_DEBUG
+    if ((dst_reg & 8) || (src_reg & 8))
+        fatal("host_x86_IMUL32_REG_IMM - dst_reg & 8\n");
+#endif
+
+    if (imm >= -128 && imm <= 127) {
+        codegen_alloc_bytes(block, 3);
+        codegen_addbyte3(block, 0x6b, 0xc0 | ((dst_reg & 7) << 3) | (src_reg & 7), (uint8_t)imm);
+    } else {
+        codegen_alloc_bytes(block, 6);
+        codegen_addbyte2(block, 0x69, 0xc0 | ((dst_reg & 7) << 3) | (src_reg & 7));
+        codegen_addlong(block, imm);
+    }
+}
+
+#endif
+

--- a/src/codegen_new/codegen_backend_x86-64_ops.h
+++ b/src/codegen_new/codegen_backend_x86-64_ops.h
@@ -194,3 +194,9 @@ void host_x86_XOR32_REG_IMM(codeblock_t *block, int dst_reg, uint32_t imm_data);
 void host_x86_XOR8_REG_REG(codeblock_t *block, int dst_reg, int src_reg);
 void host_x86_XOR16_REG_REG(codeblock_t *block, int dst_reg, int src_reg);
 void host_x86_XOR32_REG_REG(codeblock_t *block, int dst_reg, int src_reg);
+
+void host_x86_IMUL16_REG_REG(codeblock_t *block, int dst_reg, int src_reg);
+void host_x86_IMUL32_REG_REG(codeblock_t *block, int dst_reg, int src_reg);
+void host_x86_IMUL16_REG_IMM(codeblock_t *block, int dst_reg, int src_reg, int16_t imm);
+void host_x86_IMUL32_REG_IMM(codeblock_t *block, int dst_reg, int src_reg, int32_t imm);
+

--- a/src/codegen_new/codegen_backend_x86-64_uops.c
+++ b/src/codegen_new/codegen_backend_x86-64_uops.c
@@ -112,6 +112,60 @@ codegen_ADD_LSHIFT(codeblock_t *block, uop_t *uop)
 }
 
 static int
+codegen_IMUL(codeblock_t *block, uop_t *uop)
+{
+    int dest_reg   = HOST_REG_GET(uop->dest_reg_a_real);
+    int src_reg_a  = HOST_REG_GET(uop->src_reg_a_real);
+    int src_reg_b  = HOST_REG_GET(uop->src_reg_b_real);
+    int dest_size  = IREG_GET_SIZE(uop->dest_reg_a_real);
+    int src_size_a = IREG_GET_SIZE(uop->src_reg_a_real);
+    int src_size_b = IREG_GET_SIZE(uop->src_reg_b_real);
+
+    if (REG_IS_L(dest_size) && REG_IS_L(src_size_a) && REG_IS_L(src_size_b)) {
+        if (dest_reg == src_reg_b) {
+            host_x86_IMUL32_REG_REG(block, dest_reg, src_reg_a);
+        } else {
+            if (dest_reg != src_reg_a)
+                host_x86_MOV32_REG_REG(block, dest_reg, src_reg_a);
+            host_x86_IMUL32_REG_REG(block, dest_reg, src_reg_b);
+        }
+    } else if (REG_IS_W(dest_size) && REG_IS_W(src_size_a) && REG_IS_W(src_size_b)) {
+        if (dest_reg == src_reg_b) {
+            host_x86_IMUL16_REG_REG(block, dest_reg, src_reg_a);
+        } else {
+            if (dest_reg != src_reg_a)
+                host_x86_MOV16_REG_REG(block, dest_reg, src_reg_a);
+            host_x86_IMUL16_REG_REG(block, dest_reg, src_reg_b);
+        }
+    }
+#    ifdef RECOMPILER_DEBUG
+    else
+        fatal("IMUL size mismatch: dest_size=%x, src_size_a=%x, src_size_b=%x\n", dest_size, src_size_a, src_size_b);
+#    endif
+    return 0;
+}
+
+static int
+codegen_IMUL_IMM(codeblock_t *block, uop_t *uop)
+{
+    int dest_reg  = HOST_REG_GET(uop->dest_reg_a_real);
+    int src_reg   = HOST_REG_GET(uop->src_reg_a_real);
+    int dest_size = IREG_GET_SIZE(uop->dest_reg_a_real);
+    int src_size  = IREG_GET_SIZE(uop->src_reg_a_real);
+
+    if (REG_IS_L(dest_size) && REG_IS_L(src_size)) {
+        host_x86_IMUL32_REG_IMM(block, dest_reg, src_reg, uop->imm_data);
+    } else if (REG_IS_W(dest_size) && REG_IS_W(src_size)) {
+        host_x86_IMUL16_REG_IMM(block, dest_reg, src_reg, (int16_t)uop->imm_data);
+    }
+#    ifdef RECOMPILER_DEBUG
+    else
+        fatal("IMUL_IMM size mismatch: dest_size=%x, src_size=%x\n", dest_size, src_size);
+#    endif
+    return 0;
+}
+
+static int
 codegen_AND(codeblock_t *block, uop_t *uop)
 {
     int dest_reg   = HOST_REG_GET(uop->dest_reg_a_real);
@@ -3003,6 +3057,12 @@ const uOpFn uop_handlers[UOP_MAX] = {
     [UOP_ADD_IMM &
         UOP_MASK]
     = codegen_ADD_IMM,
+    [UOP_IMUL &
+        UOP_MASK]
+    = codegen_IMUL,
+    [UOP_IMUL_IMM &
+        UOP_MASK]
+    = codegen_IMUL_IMM,
     [UOP_ADD_LSHIFT &
         UOP_MASK]
     = codegen_ADD_LSHIFT,

--- a/src/codegen_new/codegen_ir_defs.h
+++ b/src/codegen_new/codegen_ir_defs.h
@@ -108,6 +108,10 @@
 #define UOP_XOR_IMM (UOP_TYPE_PARAMS_REGS | UOP_TYPE_PARAMS_IMM | 0x3a)
 /*UOP_ANDN - dest_reg = ~src_reg_a & src_reg_b*/
 #define UOP_ANDN (UOP_TYPE_PARAMS_REGS | UOP_TYPE_PARAMS_IMM | 0x3b)
+/*UOP_IMUL - dest_reg = src_reg_a * src_reg_b*/
+#define UOP_IMUL (UOP_TYPE_PARAMS_REGS | 0x3c)
+/*UOP_IMUL_IMM - dest_reg = src_reg_a * immediate*/
+#define UOP_IMUL_IMM (UOP_TYPE_PARAMS_REGS | UOP_TYPE_PARAMS_IMM | 0x3d)
 /*UOP_MEM_LOAD_ABS - dest_reg = src_reg_a:[immediate]*/
 #define UOP_MEM_LOAD_ABS (UOP_TYPE_PARAMS_REGS | UOP_TYPE_PARAMS_IMM | 0x40 | UOP_TYPE_ORDER_BARRIER)
 /*UOP_MEM_LOAD_REG - dest_reg = src_reg_a:[src_reg_b]*/
@@ -704,6 +708,8 @@ extern int codegen_fp_enter(void);
 #define uop_SUB_IMM(ir, dst_reg, src_reg, imm)                   uop_gen_reg_dst_src_imm(UOP_SUB_IMM, ir, dst_reg, src_reg, imm)
 #define uop_XOR(ir, dst_reg, src_reg_a, src_reg_b)               uop_gen_reg_dst_src2(UOP_XOR, ir, dst_reg, src_reg_a, src_reg_b)
 #define uop_XOR_IMM(ir, dst_reg, src_reg, imm)                   uop_gen_reg_dst_src_imm(UOP_XOR_IMM, ir, dst_reg, src_reg, imm)
+#define uop_IMUL(ir, dst_reg, src_reg_a, src_reg_b)              uop_gen_reg_dst_src2(UOP_IMUL, ir, dst_reg, src_reg_a, src_reg_b)
+#define uop_IMUL_IMM(ir, dst_reg, src_reg, imm)                  uop_gen_reg_dst_src_imm(UOP_IMUL_IMM, ir, dst_reg, src_reg, imm)
 
 #define uop_SAR(ir, dst_reg, src_reg, shift_reg)                 uop_gen_reg_dst_src2(UOP_SAR, ir, dst_reg, src_reg, shift_reg)
 #define uop_SAR_IMM(ir, dst_reg, src_reg, imm)                   uop_gen_reg_dst_src_imm(UOP_SAR_IMM, ir, dst_reg, src_reg, imm)

--- a/src/codegen_new/codegen_ops.c
+++ b/src/codegen_new/codegen_ops.c
@@ -46,7 +46,7 @@ RecompOpFn recomp_opcodes[512] = {
 
 /*40*/  ropINC_r16,     ropINC_r16,     ropINC_r16,     ropINC_r16,     ropINC_r16,     ropINC_r16,     ropINC_r16,     ropINC_r16,     ropDEC_r16,     ropDEC_r16,     ropDEC_r16,     ropDEC_r16,     ropDEC_r16,     ropDEC_r16,     ropDEC_r16,     ropDEC_r16,
 /*50*/  ropPUSH_r16,    ropPUSH_r16,    ropPUSH_r16,    ropPUSH_r16,    ropPUSH_r16,    ropPUSH_r16,    ropPUSH_r16,    ropPUSH_r16,    ropPOP_r16,     ropPOP_r16,     ropPOP_r16,     ropPOP_r16,     ropPOP_r16,     ropPOP_r16,     ropPOP_r16,     ropPOP_r16,
-/*60*/  ropPUSHA_16,    ropPOPA_16,     NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           ropPUSH_imm_16, NULL,           ropPUSH_imm_16_8,NULL,           NULL,           NULL,           NULL,           NULL,
+/*60*/  ropPUSHA_16,    ropPOPA_16,     NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           ropPUSH_imm_16, ropIMUL_w_rm_imm16, ropPUSH_imm_16_8,ropIMUL_w_rm_imm8, NULL,           NULL,           NULL,           NULL,
 /*70*/  ropJO_8,        ropJNO_8,       ropJB_8,        ropJNB_8,       ropJE_8,        ropJNE_8,       ropJBE_8,       ropJNBE_8,      ropJS_8,        ropJNS_8,       ropJP_8,        ropJNP_8,       ropJL_8,        ropJNL_8,       ropJLE_8,       ropJNLE_8,
 
 /*80*/  rop80,          rop81_w,        rop80,          rop83_w,        ropTEST_b_rm,   ropTEST_w_rm,   ropXCHG_8,      ropXCHG_16,     ropMOV_b_r,     ropMOV_w_r,     ropMOV_r_b,     ropMOV_r_w,     ropMOV_w_seg,   ropLEA_16,      ropMOV_seg_w,   ropPOP_W,
@@ -68,7 +68,7 @@ RecompOpFn recomp_opcodes[512] = {
 
 /*40*/  ropINC_r32,     ropINC_r32,     ropINC_r32,     ropINC_r32,     ropINC_r32,     ropINC_r32,     ropINC_r32,     ropINC_r32,     ropDEC_r32,     ropDEC_r32,     ropDEC_r32,     ropDEC_r32,     ropDEC_r32,     ropDEC_r32,     ropDEC_r32,     ropDEC_r32,
 /*50*/  ropPUSH_r32,    ropPUSH_r32,    ropPUSH_r32,    ropPUSH_r32,    ropPUSH_r32,    ropPUSH_r32,    ropPUSH_r32,    ropPUSH_r32,    ropPOP_r32,     ropPOP_r32,     ropPOP_r32,     ropPOP_r32,     ropPOP_r32,     ropPOP_r32,     ropPOP_r32,     ropPOP_r32,
-/*60*/  ropPUSHA_32,    ropPOPA_32,     NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           ropPUSH_imm_32, NULL,           ropPUSH_imm_32_8,NULL,           NULL,           NULL,           NULL,           NULL,
+/*60*/  ropPUSHA_32,    ropPOPA_32,     NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           ropPUSH_imm_32, ropIMUL_l_rm_imm32, ropPUSH_imm_32_8,ropIMUL_l_rm_imm8, NULL,           NULL,           NULL,           NULL,
 /*70*/  ropJO_8,        ropJNO_8,       ropJB_8,        ropJNB_8,       ropJE_8,        ropJNE_8,       ropJBE_8,       ropJNBE_8,      ropJS_8,        ropJNS_8,       ropJP_8,        ropJNP_8,       ropJL_8,        ropJNL_8,       ropJLE_8,       ropJNLE_8,
 
 /*80*/  rop80,          rop81_l,        rop80,          rop83_l,        ropTEST_b_rm,   ropTEST_l_rm,   ropXCHG_8,      ropXCHG_32,     ropMOV_b_r,     ropMOV_l_r,     ropMOV_r_b,     ropMOV_r_l,     ropMOV_l_seg,   ropLEA_32,      ropMOV_seg_w,   ropPOP_L,
@@ -99,10 +99,10 @@ RecompOpFn recomp_opcodes_0f[512] = {
 
 /*80*/  ropJO_16,       ropJNO_16,      ropJB_16,       ropJNB_16,      ropJE_16,       ropJNE_16,      ropJBE_16,      ropJNBE_16,     ropJS_16,       ropJNS_16,      ropJP_16,       ropJNP_16,      ropJL_16,       ropJNL_16,      ropJLE_16,      ropJNLE_16,
 /*90*/  NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,
-/*a0*/  ropPUSH_FS_16,  ropPOP_FS_16,   NULL,           NULL,           ropSHLD_16_imm, NULL,           NULL,           NULL,           ropPUSH_GS_16,  ropPOP_GS_16,   NULL,           NULL,           ropSHRD_16_imm, NULL,           NULL,           NULL,
+/*a0*/  ropPUSH_FS_16,  ropPOP_FS_16,   NULL,           NULL,           ropSHLD_16_imm, NULL,           NULL,           NULL,           ropPUSH_GS_16,  ropPOP_GS_16,   NULL,           NULL,           ropSHRD_16_imm, NULL,           NULL,           ropIMUL_w_rm,
 /*b0*/  NULL,           NULL,           ropLSS_16,      NULL,           ropLFS_16,      ropLGS_16,      ropMOVZX_16_8,  NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           ropMOVSX_16_8,  NULL,
 
-/*c0*/  NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,
+/*c0*/  ropXADD_b,      ropXADD_w,      NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,
 /*d0*/  NULL,           NULL,           NULL,           NULL,           NULL,           ropPMULLW,      NULL,           NULL,           ropPSUBUSB,     ropPSUBUSW,     NULL,           ropPAND,        ropPADDUSB,     ropPADDUSW,     NULL,           ropPANDN,
 /*e0*/  NULL,           NULL,           NULL,           NULL,           NULL,           ropPMULHW,      NULL,           NULL,           ropPSUBSB,      ropPSUBSW,      NULL,           ropPOR,         ropPADDSB,      ropPADDSW,      NULL,           ropPXOR,
 #if defined __ARM_EABI__ || defined _ARM_ || defined _M_ARM || defined __aarch64__ || defined _M_ARM64
@@ -125,10 +125,10 @@ RecompOpFn recomp_opcodes_0f[512] = {
 
 /*80*/  ropJO_32,       ropJNO_32,      ropJB_32,       ropJNB_32,      ropJE_32,       ropJNE_32,      ropJBE_32,      ropJNBE_32,     ropJS_32,       ropJNS_32,      ropJP_32,       ropJNP_32,      ropJL_32,       ropJNL_32,      ropJLE_32,      ropJNLE_32,
 /*90*/  NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,
-/*a0*/  ropPUSH_FS_32,  ropPOP_FS_32,   NULL,           NULL,           ropSHLD_32_imm, NULL,           NULL,           NULL,           ropPUSH_GS_32,  ropPOP_GS_32,   NULL,           NULL,           ropSHRD_32_imm, NULL,           NULL,           NULL,
+/*a0*/  ropPUSH_FS_32,  ropPOP_FS_32,   NULL,           NULL,           ropSHLD_32_imm, NULL,           NULL,           NULL,           ropPUSH_GS_32,  ropPOP_GS_32,   NULL,           NULL,           ropSHRD_32_imm, NULL,           NULL,           ropIMUL_l_rm,
 /*b0*/  NULL,           NULL,           ropLSS_32,      NULL,           ropLFS_32,      ropLGS_32,      ropMOVZX_32_8,  ropMOVZX_32_16, NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           ropMOVSX_32_8,  ropMOVSX_32_16,
 
-/*c0*/  NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,
+/*c0*/  ropXADD_b,      ropXADD_l,      NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,
 /*d0*/  NULL,           NULL,           NULL,           NULL,           NULL,           ropPMULLW,      NULL,           NULL,           ropPSUBUSB,     ropPSUBUSW,     NULL,           ropPAND,        ropPADDUSB,     ropPADDUSW,     NULL,           ropPANDN,
 /*e0*/  NULL,           NULL,           NULL,           NULL,           NULL,           ropPMULHW,      NULL,           NULL,           ropPSUBSB,      ropPSUBSW,      NULL,           ropPOR,         ropPADDSB,      ropPADDSW,      NULL,           ropPXOR,
 #if defined __ARM_EABI__ || defined _ARM_ || defined _M_ARM || defined __aarch64__ || defined _M_ARM64
@@ -155,10 +155,10 @@ RecompOpFn recomp_opcodes_0f_no_mmx[512] = {
 
 /*80*/  ropJO_16,       ropJNO_16,      ropJB_16,       ropJNB_16,      ropJE_16,       ropJNE_16,      ropJBE_16,      ropJNBE_16,     ropJS_16,       ropJNS_16,      ropJP_16,       ropJNP_16,      ropJL_16,       ropJNL_16,      ropJLE_16,      ropJNLE_16,
 /*90*/  NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,
-/*a0*/  ropPUSH_FS_16,  ropPOP_FS_16,   NULL,           NULL,           ropSHLD_16_imm, NULL,           NULL,           NULL,           ropPUSH_GS_16,  ropPOP_GS_16,   NULL,           NULL,           ropSHRD_16_imm, NULL,           NULL,           NULL,
+/*a0*/  ropPUSH_FS_16,  ropPOP_FS_16,   NULL,           NULL,           ropSHLD_16_imm, NULL,           NULL,           NULL,           ropPUSH_GS_16,  ropPOP_GS_16,   NULL,           NULL,           ropSHRD_16_imm, NULL,           NULL,           ropIMUL_w_rm,
 /*b0*/  NULL,           NULL,           ropLSS_16,      NULL,           ropLFS_16,      ropLGS_16,      ropMOVZX_16_8,  NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           ropMOVSX_16_8,  NULL,
 
-/*c0*/  NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,
+/*c0*/  ropXADD_b,      ropXADD_w,      NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,
 /*d0*/  NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,
 /*e0*/  NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,
 /*f0*/  NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,
@@ -177,10 +177,10 @@ RecompOpFn recomp_opcodes_0f_no_mmx[512] = {
 
 /*80*/  ropJO_32,       ropJNO_32,      ropJB_32,       ropJNB_32,      ropJE_32,       ropJNE_32,      ropJBE_32,      ropJNBE_32,     ropJS_32,       ropJNS_32,      ropJP_32,       ropJNP_32,      ropJL_32,       ropJNL_32,      ropJLE_32,      ropJNLE_32,
 /*90*/  NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,
-/*a0*/  ropPUSH_FS_32,  ropPOP_FS_32,   NULL,           NULL,           ropSHLD_32_imm, NULL,           NULL,           NULL,           ropPUSH_GS_32,  ropPOP_GS_32,   NULL,           NULL,           ropSHRD_32_imm, NULL,           NULL,           NULL,
+/*a0*/  ropPUSH_FS_32,  ropPOP_FS_32,   NULL,           NULL,           ropSHLD_32_imm, NULL,           NULL,           NULL,           ropPUSH_GS_32,  ropPOP_GS_32,   NULL,           NULL,           ropSHRD_32_imm, NULL,           NULL,           ropIMUL_l_rm,
 /*b0*/  NULL,           NULL,           ropLSS_32,      NULL,           ropLFS_32,      ropLGS_32,      ropMOVZX_32_8,  ropMOVZX_32_16, NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           ropMOVSX_32_8,  ropMOVSX_32_16,
 
-/*c0*/  NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,
+/*c0*/  ropXADD_b,      ropXADD_l,      NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,
 /*d0*/  NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,
 /*e0*/  NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,
 /*f0*/  NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,           NULL,

--- a/src/codegen_new/codegen_ops_arith.c
+++ b/src/codegen_new/codegen_ops_arith.c
@@ -2394,3 +2394,318 @@ ropINCDEC(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fe
 
     return op_pc + 1;
 }
+
+uint32_t
+ropXADD_b(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fetchdat, uint32_t op_32, uint32_t op_pc)
+{
+    int src_reg = (fetchdat >> 3) & 7;
+
+    codegen_mark_code_present(block, cs + op_pc, 1);
+    if ((fetchdat & 0xc0) == 0xc0) {
+        int dest_reg = fetchdat & 7;
+
+        uop_MOV(ir, IREG_temp0_B, IREG_8(dest_reg));
+        uop_MOVZX(ir, IREG_flags_op1, IREG_8(dest_reg));
+        uop_MOVZX(ir, IREG_flags_op2, IREG_8(src_reg));
+        uop_ADD(ir, IREG_8(dest_reg), IREG_8(dest_reg), IREG_8(src_reg));
+        uop_MOV(ir, IREG_8(src_reg), IREG_temp0_B);
+        uop_MOVZX(ir, IREG_flags_res, IREG_8(dest_reg));
+    } else {
+        x86seg *target_seg;
+
+        uop_MOV_IMM(ir, IREG_oldpc, cpu_state.oldpc);
+        target_seg = codegen_generate_ea(ir, op_ea_seg, fetchdat, op_ssegs, &op_pc, op_32, 0);
+        codegen_check_seg_write(block, ir, target_seg);
+
+        uop_MEM_LOAD_REG(ir, IREG_temp0_B, ireg_seg_base(target_seg), IREG_eaaddr);
+        uop_ADD(ir, IREG_temp1_B, IREG_temp0_B, IREG_8(src_reg));
+        uop_MEM_STORE_REG(ir, ireg_seg_base(target_seg), IREG_eaaddr, IREG_temp1_B);
+        uop_MOVZX(ir, IREG_flags_op1, IREG_temp0_B);
+        uop_MOVZX(ir, IREG_flags_op2, IREG_8(src_reg));
+        uop_MOVZX(ir, IREG_flags_res, IREG_temp1_B);
+        uop_MOV(ir, IREG_8(src_reg), IREG_temp0_B);
+    }
+    uop_MOV_IMM(ir, IREG_flags_op, FLAGS_ADD8);
+    codegen_flags_changed = 1;
+    return op_pc + 1;
+}
+
+uint32_t
+ropXADD_w(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fetchdat, uint32_t op_32, uint32_t op_pc)
+{
+    int src_reg = (fetchdat >> 3) & 7;
+
+    codegen_mark_code_present(block, cs + op_pc, 1);
+    if ((fetchdat & 0xc0) == 0xc0) {
+        int dest_reg = fetchdat & 7;
+
+        uop_MOV(ir, IREG_temp0_W, IREG_16(dest_reg));
+        uop_MOVZX(ir, IREG_flags_op1, IREG_16(dest_reg));
+        uop_MOVZX(ir, IREG_flags_op2, IREG_16(src_reg));
+        uop_ADD(ir, IREG_16(dest_reg), IREG_16(dest_reg), IREG_16(src_reg));
+        uop_MOV(ir, IREG_16(src_reg), IREG_temp0_W);
+        uop_MOVZX(ir, IREG_flags_res, IREG_16(dest_reg));
+    } else {
+        x86seg *target_seg;
+
+        uop_MOV_IMM(ir, IREG_oldpc, cpu_state.oldpc);
+        target_seg = codegen_generate_ea(ir, op_ea_seg, fetchdat, op_ssegs, &op_pc, op_32, 0);
+        codegen_check_seg_write(block, ir, target_seg);
+
+        uop_MEM_LOAD_REG(ir, IREG_temp0_W, ireg_seg_base(target_seg), IREG_eaaddr);
+        uop_ADD(ir, IREG_temp1_W, IREG_temp0_W, IREG_16(src_reg));
+        uop_MEM_STORE_REG(ir, ireg_seg_base(target_seg), IREG_eaaddr, IREG_temp1_W);
+        uop_MOVZX(ir, IREG_flags_op1, IREG_temp0_W);
+        uop_MOVZX(ir, IREG_flags_op2, IREG_16(src_reg));
+        uop_MOVZX(ir, IREG_flags_res, IREG_temp1_W);
+        uop_MOV(ir, IREG_16(src_reg), IREG_temp0_W);
+    }
+    uop_MOV_IMM(ir, IREG_flags_op, FLAGS_ADD16);
+    codegen_flags_changed = 1;
+    return op_pc + 1;
+}
+
+uint32_t
+ropXADD_l(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fetchdat, uint32_t op_32, uint32_t op_pc)
+{
+    int src_reg = (fetchdat >> 3) & 7;
+
+    codegen_mark_code_present(block, cs + op_pc, 1);
+    if ((fetchdat & 0xc0) == 0xc0) {
+        int dest_reg = fetchdat & 7;
+
+        uop_MOV(ir, IREG_temp0, IREG_32(dest_reg));
+        uop_MOV(ir, IREG_flags_op1, IREG_32(dest_reg));
+        uop_MOV(ir, IREG_flags_op2, IREG_32(src_reg));
+        uop_ADD(ir, IREG_32(dest_reg), IREG_32(dest_reg), IREG_32(src_reg));
+        uop_MOV(ir, IREG_32(src_reg), IREG_temp0);
+        uop_MOV(ir, IREG_flags_res, IREG_32(dest_reg));
+    } else {
+        x86seg *target_seg;
+
+        uop_MOV_IMM(ir, IREG_oldpc, cpu_state.oldpc);
+        target_seg = codegen_generate_ea(ir, op_ea_seg, fetchdat, op_ssegs, &op_pc, op_32, 0);
+        codegen_check_seg_write(block, ir, target_seg);
+
+        uop_MEM_LOAD_REG(ir, IREG_temp0, ireg_seg_base(target_seg), IREG_eaaddr);
+        uop_ADD(ir, IREG_temp1, IREG_temp0, IREG_32(src_reg));
+        uop_MEM_STORE_REG(ir, ireg_seg_base(target_seg), IREG_eaaddr, IREG_temp1);
+        uop_MOV(ir, IREG_flags_op1, IREG_temp0);
+        uop_MOV(ir, IREG_flags_op2, IREG_32(src_reg));
+        uop_MOV(ir, IREG_flags_res, IREG_temp1);
+        uop_MOV(ir, IREG_32(src_reg), IREG_temp0);
+    }
+    uop_MOV_IMM(ir, IREG_flags_op, FLAGS_ADD32);
+    codegen_flags_changed = 1;
+    return op_pc + 1;
+}
+
+uint32_t
+ropIMUL_w_rm(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fetchdat, uint32_t op_32, uint32_t op_pc)
+{
+    int dest_reg = (fetchdat >> 3) & 7;
+
+    codegen_mark_code_present(block, cs + op_pc, 1);
+    if ((fetchdat & 0xc0) == 0xc0) {
+        int src_reg = fetchdat & 7;
+
+        uop_MOVZX(ir, IREG_flags_op1, IREG_16(dest_reg));
+        uop_MOVZX(ir, IREG_flags_op2, IREG_16(src_reg));
+        uop_IMUL(ir, IREG_16(dest_reg), IREG_16(dest_reg), IREG_16(src_reg));
+    } else {
+        x86seg *target_seg;
+
+        uop_MOV_IMM(ir, IREG_oldpc, cpu_state.oldpc);
+        target_seg = codegen_generate_ea(ir, op_ea_seg, fetchdat, op_ssegs, &op_pc, op_32, 0);
+        codegen_check_seg_read(block, ir, target_seg);
+
+        uop_MEM_LOAD_REG(ir, IREG_temp0_W, ireg_seg_base(target_seg), IREG_eaaddr);
+        uop_MOVZX(ir, IREG_flags_op1, IREG_16(dest_reg));
+        uop_MOVZX(ir, IREG_flags_op2, IREG_temp0_W);
+        uop_IMUL(ir, IREG_16(dest_reg), IREG_16(dest_reg), IREG_temp0_W);
+    }
+
+    uop_MOV_IMM(ir, IREG_flags_op, FLAGS_IMUL16);
+    uop_MOVZX(ir, IREG_flags_res, IREG_16(dest_reg));
+    codegen_flags_changed = 1;
+    return op_pc + 1;
+}
+
+uint32_t
+ropIMUL_l_rm(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fetchdat, uint32_t op_32, uint32_t op_pc)
+{
+    int dest_reg = (fetchdat >> 3) & 7;
+
+    codegen_mark_code_present(block, cs + op_pc, 1);
+    if ((fetchdat & 0xc0) == 0xc0) {
+        int src_reg = fetchdat & 7;
+
+        uop_MOV(ir, IREG_flags_op1, IREG_32(dest_reg));
+        uop_MOV(ir, IREG_flags_op2, IREG_32(src_reg));
+        uop_IMUL(ir, IREG_32(dest_reg), IREG_32(dest_reg), IREG_32(src_reg));
+    } else {
+        x86seg *target_seg;
+
+        uop_MOV_IMM(ir, IREG_oldpc, cpu_state.oldpc);
+        target_seg = codegen_generate_ea(ir, op_ea_seg, fetchdat, op_ssegs, &op_pc, op_32, 0);
+        codegen_check_seg_read(block, ir, target_seg);
+
+        uop_MEM_LOAD_REG(ir, IREG_temp0, ireg_seg_base(target_seg), IREG_eaaddr);
+        uop_MOV(ir, IREG_flags_op1, IREG_32(dest_reg));
+        uop_MOV(ir, IREG_flags_op2, IREG_temp0);
+        uop_IMUL(ir, IREG_32(dest_reg), IREG_32(dest_reg), IREG_temp0);
+    }
+
+    uop_MOV_IMM(ir, IREG_flags_op, FLAGS_IMUL32);
+    uop_MOV(ir, IREG_flags_res, IREG_32(dest_reg));
+    codegen_flags_changed = 1;
+    return op_pc + 1;
+}
+
+uint32_t
+ropIMUL_w_rm_imm16(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fetchdat, uint32_t op_32, uint32_t op_pc)
+{
+    int dest_reg = (fetchdat >> 3) & 7;
+    uint32_t start_pc = op_pc;
+
+    codegen_mark_code_present(block, cs + op_pc, 1);
+    if ((fetchdat & 0xc0) == 0xc0) {
+        int src_reg = fetchdat & 7;
+        uint16_t imm = fastreadw(cs + op_pc + 1);
+
+        uop_MOVZX(ir, IREG_flags_op1, IREG_16(src_reg));
+        uop_MOV_IMM(ir, IREG_flags_op2, imm);
+        uop_IMUL_IMM(ir, IREG_16(dest_reg), IREG_16(src_reg), imm);
+        op_pc += 3;
+    } else {
+        x86seg *target_seg;
+
+        uop_MOV_IMM(ir, IREG_oldpc, cpu_state.oldpc);
+        target_seg = codegen_generate_ea(ir, op_ea_seg, fetchdat, op_ssegs, &op_pc, op_32, 0);
+        codegen_check_seg_read(block, ir, target_seg);
+
+        uint16_t imm = fastreadw(cs + op_pc + 1);
+        uop_MEM_LOAD_REG(ir, IREG_temp0_W, ireg_seg_base(target_seg), IREG_eaaddr);
+        uop_MOVZX(ir, IREG_flags_op1, IREG_temp0_W);
+        uop_MOV_IMM(ir, IREG_flags_op2, imm);
+        uop_IMUL_IMM(ir, IREG_16(dest_reg), IREG_temp0_W, imm);
+        op_pc += 3;
+    }
+
+    uop_MOV_IMM(ir, IREG_flags_op, FLAGS_IMUL16);
+    uop_MOVZX(ir, IREG_flags_res, IREG_16(dest_reg));
+    codegen_mark_code_present(block, cs + start_pc + 1, op_pc - (start_pc + 1));
+    codegen_flags_changed = 1;
+    return op_pc;
+}
+
+uint32_t
+ropIMUL_l_rm_imm32(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fetchdat, uint32_t op_32, uint32_t op_pc)
+{
+    int dest_reg = (fetchdat >> 3) & 7;
+    uint32_t start_pc = op_pc;
+
+    codegen_mark_code_present(block, cs + op_pc, 1);
+    if ((fetchdat & 0xc0) == 0xc0) {
+        int src_reg = fetchdat & 7;
+        uint32_t imm = fastreadl(cs + op_pc + 1);
+
+        uop_MOV(ir, IREG_flags_op1, IREG_32(src_reg));
+        uop_MOV_IMM(ir, IREG_flags_op2, imm);
+        uop_IMUL_IMM(ir, IREG_32(dest_reg), IREG_32(src_reg), imm);
+        op_pc += 5;
+    } else {
+        x86seg *target_seg;
+
+        uop_MOV_IMM(ir, IREG_oldpc, cpu_state.oldpc);
+        target_seg = codegen_generate_ea(ir, op_ea_seg, fetchdat, op_ssegs, &op_pc, op_32, 0);
+        codegen_check_seg_read(block, ir, target_seg);
+
+        uint32_t imm = fastreadl(cs + op_pc + 1);
+        uop_MEM_LOAD_REG(ir, IREG_temp0, ireg_seg_base(target_seg), IREG_eaaddr);
+        uop_MOV(ir, IREG_flags_op1, IREG_temp0);
+        uop_MOV_IMM(ir, IREG_flags_op2, imm);
+        uop_IMUL_IMM(ir, IREG_32(dest_reg), IREG_temp0, imm);
+        op_pc += 5;
+    }
+
+    uop_MOV_IMM(ir, IREG_flags_op, FLAGS_IMUL32);
+    uop_MOV(ir, IREG_flags_res, IREG_32(dest_reg));
+    codegen_mark_code_present(block, cs + start_pc + 1, op_pc - (start_pc + 1));
+    codegen_flags_changed = 1;
+    return op_pc;
+}
+
+uint32_t
+ropIMUL_w_rm_imm8(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fetchdat, uint32_t op_32, uint32_t op_pc)
+{
+    int dest_reg = (fetchdat >> 3) & 7;
+    uint32_t start_pc = op_pc;
+
+    codegen_mark_code_present(block, cs + op_pc, 1);
+    if ((fetchdat & 0xc0) == 0xc0) {
+        int src_reg = fetchdat & 7;
+        int16_t imm = (int16_t)(int8_t)fastreadb(cs + op_pc + 1);
+
+        uop_MOVZX(ir, IREG_flags_op1, IREG_16(src_reg));
+        uop_MOV_IMM(ir, IREG_flags_op2, (uint16_t)imm);
+        uop_IMUL_IMM(ir, IREG_16(dest_reg), IREG_16(src_reg), (uint16_t)imm);
+        op_pc += 2;
+    } else {
+        x86seg *target_seg;
+
+        uop_MOV_IMM(ir, IREG_oldpc, cpu_state.oldpc);
+        target_seg = codegen_generate_ea(ir, op_ea_seg, fetchdat, op_ssegs, &op_pc, op_32, 0);
+        codegen_check_seg_read(block, ir, target_seg);
+
+        int16_t imm = (int16_t)(int8_t)fastreadb(cs + op_pc + 1);
+        uop_MEM_LOAD_REG(ir, IREG_temp0_W, ireg_seg_base(target_seg), IREG_eaaddr);
+        uop_MOVZX(ir, IREG_flags_op1, IREG_temp0_W);
+        uop_MOV_IMM(ir, IREG_flags_op2, (uint16_t)imm);
+        uop_IMUL_IMM(ir, IREG_16(dest_reg), IREG_temp0_W, (uint16_t)imm);
+        op_pc += 2;
+    }
+
+    uop_MOV_IMM(ir, IREG_flags_op, FLAGS_IMUL16);
+    uop_MOVZX(ir, IREG_flags_res, IREG_16(dest_reg));
+    codegen_mark_code_present(block, cs + start_pc + 1, op_pc - (start_pc + 1));
+    codegen_flags_changed = 1;
+    return op_pc;
+}
+
+uint32_t
+ropIMUL_l_rm_imm8(codeblock_t *block, ir_data_t *ir, UNUSED(uint8_t opcode), uint32_t fetchdat, uint32_t op_32, uint32_t op_pc)
+{
+    int dest_reg = (fetchdat >> 3) & 7;
+    uint32_t start_pc = op_pc;
+
+    codegen_mark_code_present(block, cs + op_pc, 1);
+    if ((fetchdat & 0xc0) == 0xc0) {
+        int src_reg = fetchdat & 7;
+        int32_t imm = (int32_t)(int8_t)fastreadb(cs + op_pc + 1);
+
+        uop_MOV(ir, IREG_flags_op1, IREG_32(src_reg));
+        uop_MOV_IMM(ir, IREG_flags_op2, (uint32_t)imm);
+        uop_IMUL_IMM(ir, IREG_32(dest_reg), IREG_32(src_reg), (uint32_t)imm);
+        op_pc += 2;
+    } else {
+        x86seg *target_seg;
+
+        uop_MOV_IMM(ir, IREG_oldpc, cpu_state.oldpc);
+        target_seg = codegen_generate_ea(ir, op_ea_seg, fetchdat, op_ssegs, &op_pc, op_32, 0);
+        codegen_check_seg_read(block, ir, target_seg);
+
+        int32_t imm = (int32_t)(int8_t)fastreadb(cs + op_pc + 1);
+        uop_MEM_LOAD_REG(ir, IREG_temp0, ireg_seg_base(target_seg), IREG_eaaddr);
+        uop_MOV(ir, IREG_flags_op1, IREG_temp0);
+        uop_MOV_IMM(ir, IREG_flags_op2, (uint32_t)imm);
+        uop_IMUL_IMM(ir, IREG_32(dest_reg), IREG_temp0, (uint32_t)imm);
+        op_pc += 2;
+    }
+
+    uop_MOV_IMM(ir, IREG_flags_op, FLAGS_IMUL32);
+    uop_MOV(ir, IREG_flags_res, IREG_32(dest_reg));
+    codegen_mark_code_present(block, cs + start_pc + 1, op_pc - (start_pc + 1));
+    codegen_flags_changed = 1;
+    return op_pc;
+}

--- a/src/codegen_new/codegen_ops_arith.h
+++ b/src/codegen_new/codegen_ops_arith.h
@@ -61,3 +61,14 @@ uint32_t ropINC_r16(codeblock_t *block, ir_data_t *ir, uint8_t opcode, uint32_t 
 uint32_t ropINC_r32(codeblock_t *block, ir_data_t *ir, uint8_t opcode, uint32_t fetchdat, uint32_t op_32, uint32_t op_pc);
 
 uint32_t ropINCDEC(codeblock_t *block, ir_data_t *ir, uint8_t opcode, uint32_t fetchdat, uint32_t op_32, uint32_t op_pc);
+
+uint32_t ropXADD_b(codeblock_t *block, ir_data_t *ir, uint8_t opcode, uint32_t fetchdat, uint32_t op_32, uint32_t op_pc);
+uint32_t ropXADD_w(codeblock_t *block, ir_data_t *ir, uint8_t opcode, uint32_t fetchdat, uint32_t op_32, uint32_t op_pc);
+uint32_t ropXADD_l(codeblock_t *block, ir_data_t *ir, uint8_t opcode, uint32_t fetchdat, uint32_t op_32, uint32_t op_pc);
+
+uint32_t ropIMUL_w_rm(codeblock_t *block, ir_data_t *ir, uint8_t opcode, uint32_t fetchdat, uint32_t op_32, uint32_t op_pc);
+uint32_t ropIMUL_l_rm(codeblock_t *block, ir_data_t *ir, uint8_t opcode, uint32_t fetchdat, uint32_t op_32, uint32_t op_pc);
+uint32_t ropIMUL_w_rm_imm16(codeblock_t *block, ir_data_t *ir, uint8_t opcode, uint32_t fetchdat, uint32_t op_32, uint32_t op_pc);
+uint32_t ropIMUL_l_rm_imm32(codeblock_t *block, ir_data_t *ir, uint8_t opcode, uint32_t fetchdat, uint32_t op_32, uint32_t op_pc);
+uint32_t ropIMUL_w_rm_imm8(codeblock_t *block, ir_data_t *ir, uint8_t opcode, uint32_t fetchdat, uint32_t op_32, uint32_t op_pc);
+uint32_t ropIMUL_l_rm_imm8(codeblock_t *block, ir_data_t *ir, uint8_t opcode, uint32_t fetchdat, uint32_t op_32, uint32_t op_pc);

--- a/src/cpu/x86_flags.h
+++ b/src/cpu/x86_flags.h
@@ -780,6 +780,21 @@ setsbc32(uint32_t a, uint32_t b)
     cpu_state.flags_res = a - (b + tempc);
     cpu_state.flags_op  = FLAGS_SBC32;
 }
+
+static __inline void
+setimul16(int16_t a, int16_t b)
+{
+    cpu_state.flags_op1 = a;
+    cpu_state.flags_op2 = b;
+    cpu_state.flags_op  = FLAGS_IMUL16;
+}
+static __inline void
+setimul32(int32_t a, int32_t b)
+{
+    cpu_state.flags_op1 = a;
+    cpu_state.flags_op2 = b;
+    cpu_state.flags_op  = FLAGS_IMUL32;
+}
 #else
 static __inline void
 setadc8(uint8_t a, uint8_t b)
@@ -869,6 +884,27 @@ setsbc32(uint32_t a, uint32_t b)
         cpu_state.flags |= V_FLAG;
     if (((a & 0xF) - ((b & 0xF) + tempc)) & 0x10)
         cpu_state.flags |= A_FLAG;
+}
+
+static __inline void
+setimul16(int16_t a, int16_t b)
+{
+    int32_t res = (int32_t)a * (int32_t)b;
+    cpu_state.flags_op = FLAGS_UNKNOWN;
+    if ((res >> 15) != 0 && (res >> 15) != -1)
+        cpu_state.flags |= C_FLAG | V_FLAG;
+    else
+        cpu_state.flags &= ~(C_FLAG | V_FLAG);
+}
+static __inline void
+setimul32(int32_t a, int32_t b)
+{
+    int64_t res = (int64_t)a * (int64_t)b;
+    cpu_state.flags_op = FLAGS_UNKNOWN;
+    if ((res >> 31) != 0 && (res >> 31) != -1)
+        cpu_state.flags |= C_FLAG | V_FLAG;
+    else
+        cpu_state.flags &= ~(C_FLAG | V_FLAG);
 }
 #endif
 

--- a/src/cpu/x86_flags.h
+++ b/src/cpu/x86_flags.h
@@ -53,7 +53,10 @@ enum {
 
     FLAGS_SBC8,
     FLAGS_SBC16,
-    FLAGS_SBC32
+    FLAGS_SBC32,
+
+    FLAGS_IMUL16,
+    FLAGS_IMUL32
 #endif
 };
 
@@ -102,6 +105,8 @@ ZF_SET(void)
         case FLAGS_ROR8:
         case FLAGS_ROR16:
         case FLAGS_ROR32:
+        case FLAGS_IMUL16:
+        case FLAGS_IMUL32:
 #endif
         case FLAGS_UNKNOWN:
             return cpu_state.flags & Z_FLAG;
@@ -169,6 +174,8 @@ NF_SET(void)
         case FLAGS_ROR8:
         case FLAGS_ROR16:
         case FLAGS_ROR32:
+        case FLAGS_IMUL16:
+        case FLAGS_IMUL32:
 #endif
         case FLAGS_UNKNOWN:
             return cpu_state.flags & N_FLAG;
@@ -228,6 +235,8 @@ PF_SET(void)
         case FLAGS_ROR8:
         case FLAGS_ROR16:
         case FLAGS_ROR32:
+        case FLAGS_IMUL16:
+        case FLAGS_IMUL32:
 #endif
         case FLAGS_UNKNOWN:
             return cpu_state.flags & P_FLAG;
@@ -320,6 +329,14 @@ VF_SET(void)
             return (cpu_state.flags_res ^ (cpu_state.flags_res >> 1)) & 0x4000;
         case FLAGS_ROR32:
             return (cpu_state.flags_res ^ (cpu_state.flags_res >> 1)) & 0x40000000;
+        case FLAGS_IMUL16: {
+            int32_t res = (int32_t)(int16_t)cpu_state.flags_op1 * (int32_t)(int16_t)cpu_state.flags_op2;
+            return ((res >> 15) != 0 && (res >> 15) != -1);
+        }
+        case FLAGS_IMUL32: {
+            int64_t res = (int64_t)(int32_t)cpu_state.flags_op1 * (int64_t)(int32_t)cpu_state.flags_op2;
+            return ((res >> 31) != 0 && (res >> 31) != -1);
+        }
 #endif
 
         case FLAGS_UNKNOWN:
@@ -390,6 +407,8 @@ AF_SET(void)
         case FLAGS_ROR8:
         case FLAGS_ROR16:
         case FLAGS_ROR32:
+        case FLAGS_IMUL16:
+        case FLAGS_IMUL32:
 #endif
         case FLAGS_UNKNOWN:
             return cpu_state.flags & A_FLAG;
@@ -472,6 +491,14 @@ CF_SET(void)
             return (cpu_state.flags_res & 0x8000) ? 1 : 0;
         case FLAGS_ROR32:
             return (cpu_state.flags_res & 0x80000000) ? 1 : 0;
+        case FLAGS_IMUL16: {
+            int32_t res = (int32_t)(int16_t)cpu_state.flags_op1 * (int32_t)(int16_t)cpu_state.flags_op2;
+            return ((res >> 15) != 0 && (res >> 15) != -1);
+        }
+        case FLAGS_IMUL32: {
+            int64_t res = (int64_t)(int32_t)cpu_state.flags_op1 * (int64_t)(int32_t)cpu_state.flags_op2;
+            return ((res >> 31) != 0 && (res >> 31) != -1);
+        }
 #endif
 
         case FLAGS_DEC8:

--- a/src/cpu/x86_ops_mul.h
+++ b/src/cpu/x86_ops_mul.h
@@ -17,12 +17,8 @@ opIMUL_w_iw_a16(uint32_t fetchdat)
         return 1;
 
     templ = ((int) tempw) * ((int) tempw2);
-    flags_rebuild();
-    if ((templ >> 15) != 0 && (templ >> 15) != -1)
-        cpu_state.flags |= C_FLAG | V_FLAG;
-    else
-        cpu_state.flags &= ~(C_FLAG | V_FLAG);
     cpu_state.regs[cpu_reg].w = templ & 0xffff;
+    setimul16(tempw, tempw2);
 
     CLOCK_CYCLES((cpu_mod == 3) ? 14 : 17);
     PREFETCH_RUN((cpu_mod == 3) ? 14 : 17, 4, rmdat, 1, 0, 0, 0, 0);
@@ -47,12 +43,8 @@ opIMUL_w_iw_a32(uint32_t fetchdat)
         return 1;
 
     templ = ((int) tempw) * ((int) tempw2);
-    flags_rebuild();
-    if ((templ >> 15) != 0 && (templ >> 15) != -1)
-        cpu_state.flags |= C_FLAG | V_FLAG;
-    else
-        cpu_state.flags &= ~(C_FLAG | V_FLAG);
     cpu_state.regs[cpu_reg].w = templ & 0xffff;
+    setimul16(tempw, tempw2);
 
     CLOCK_CYCLES((cpu_mod == 3) ? 14 : 17);
     PREFETCH_RUN((cpu_mod == 3) ? 14 : 17, 4, rmdat, 1, 0, 0, 0, 1);
@@ -78,12 +70,8 @@ opIMUL_l_il_a16(uint32_t fetchdat)
         return 1;
 
     temp64 = ((int64_t) templ) * ((int64_t) templ2);
-    flags_rebuild();
-    if ((temp64 >> 31) != 0 && (temp64 >> 31) != -1)
-        cpu_state.flags |= C_FLAG | V_FLAG;
-    else
-        cpu_state.flags &= ~(C_FLAG | V_FLAG);
     cpu_state.regs[cpu_reg].l = temp64 & 0xffffffff;
+    setimul32(templ, templ2);
 
     CLOCK_CYCLES(25);
     PREFETCH_RUN(25, 6, rmdat, 0, 1, 0, 0, 0);
@@ -108,12 +96,8 @@ opIMUL_l_il_a32(uint32_t fetchdat)
         return 1;
 
     temp64 = ((int64_t) templ) * ((int64_t) templ2);
-    flags_rebuild();
-    if ((temp64 >> 31) != 0 && (temp64 >> 31) != -1)
-        cpu_state.flags |= C_FLAG | V_FLAG;
-    else
-        cpu_state.flags &= ~(C_FLAG | V_FLAG);
     cpu_state.regs[cpu_reg].l = temp64 & 0xffffffff;
+    setimul32(templ, templ2);
 
     CLOCK_CYCLES(25);
     PREFETCH_RUN(25, 6, rmdat, 0, 1, 0, 0, 1);
@@ -141,12 +125,8 @@ opIMUL_w_ib_a16(uint32_t fetchdat)
         tempw2 |= 0xff00;
 
     templ = ((int) tempw) * ((int) tempw2);
-    flags_rebuild();
-    if ((templ >> 15) != 0 && (templ >> 15) != -1)
-        cpu_state.flags |= C_FLAG | V_FLAG;
-    else
-        cpu_state.flags &= ~(C_FLAG | V_FLAG);
     cpu_state.regs[cpu_reg].w = templ & 0xffff;
+    setimul16(tempw, tempw2);
 
     CLOCK_CYCLES((cpu_mod == 3) ? 14 : 17);
     PREFETCH_RUN((cpu_mod == 3) ? 14 : 17, 3, rmdat, 1, 0, 0, 0, 0);
@@ -173,12 +153,8 @@ opIMUL_w_ib_a32(uint32_t fetchdat)
         tempw2 |= 0xff00;
 
     templ = ((int) tempw) * ((int) tempw2);
-    flags_rebuild();
-    if ((templ >> 15) != 0 && (templ >> 15) != -1)
-        cpu_state.flags |= C_FLAG | V_FLAG;
-    else
-        cpu_state.flags &= ~(C_FLAG | V_FLAG);
     cpu_state.regs[cpu_reg].w = templ & 0xffff;
+    setimul16(tempw, tempw2);
 
     CLOCK_CYCLES((cpu_mod == 3) ? 14 : 17);
     PREFETCH_RUN((cpu_mod == 3) ? 14 : 17, 3, rmdat, 1, 0, 0, 0, 1);
@@ -206,12 +182,8 @@ opIMUL_l_ib_a16(uint32_t fetchdat)
         templ2 |= 0xffffff00;
 
     temp64 = ((int64_t) templ) * ((int64_t) templ2);
-    flags_rebuild();
-    if ((temp64 >> 31) != 0 && (temp64 >> 31) != -1)
-        cpu_state.flags |= C_FLAG | V_FLAG;
-    else
-        cpu_state.flags &= ~(C_FLAG | V_FLAG);
     cpu_state.regs[cpu_reg].l = temp64 & 0xffffffff;
+    setimul32(templ, templ2);
 
     CLOCK_CYCLES(20);
     PREFETCH_RUN(20, 3, rmdat, 0, 1, 0, 0, 0);
@@ -238,12 +210,8 @@ opIMUL_l_ib_a32(uint32_t fetchdat)
         templ2 |= 0xffffff00;
 
     temp64 = ((int64_t) templ) * ((int64_t) templ2);
-    flags_rebuild();
-    if ((temp64 >> 31) != 0 && (temp64 >> 31) != -1)
-        cpu_state.flags |= C_FLAG | V_FLAG;
-    else
-        cpu_state.flags &= ~(C_FLAG | V_FLAG);
     cpu_state.regs[cpu_reg].l = temp64 & 0xffffffff;
+    setimul32(templ, templ2);
 
     CLOCK_CYCLES(20);
     PREFETCH_RUN(20, 3, rmdat, 0, 1, 0, 0, 1);
@@ -259,15 +227,13 @@ opIMUL_w_w_a16(uint32_t fetchdat)
     if (cpu_mod != 3)
         SEG_CHECK_READ(cpu_state.ea_seg);
 
-    templ = (int32_t) (int16_t) cpu_state.regs[cpu_reg].w * (int32_t) (int16_t) geteaw();
+    int16_t op1 = cpu_state.regs[cpu_reg].w;
+    int16_t op2 = geteaw();
     if (cpu_state.abrt)
         return 1;
+    templ = (int32_t) op1 * (int32_t) op2;
     cpu_state.regs[cpu_reg].w = templ & 0xFFFF;
-    flags_rebuild();
-    if ((templ >> 15) != 0 && (templ >> 15) != -1)
-        cpu_state.flags |= C_FLAG | V_FLAG;
-    else
-        cpu_state.flags &= ~(C_FLAG | V_FLAG);
+    setimul16(op1, op2);
 
     CLOCK_CYCLES(18);
     PREFETCH_RUN(18, 2, rmdat, 1, 0, 0, 0, 0);
@@ -282,15 +248,13 @@ opIMUL_w_w_a32(uint32_t fetchdat)
     if (cpu_mod != 3)
         SEG_CHECK_READ(cpu_state.ea_seg);
 
-    templ = (int32_t) (int16_t) cpu_state.regs[cpu_reg].w * (int32_t) (int16_t) geteaw();
+    int16_t op1 = cpu_state.regs[cpu_reg].w;
+    int16_t op2 = geteaw();
     if (cpu_state.abrt)
         return 1;
+    templ = (int32_t) op1 * (int32_t) op2;
     cpu_state.regs[cpu_reg].w = templ & 0xFFFF;
-    flags_rebuild();
-    if ((templ >> 15) != 0 && (templ >> 15) != -1)
-        cpu_state.flags |= C_FLAG | V_FLAG;
-    else
-        cpu_state.flags &= ~(C_FLAG | V_FLAG);
+    setimul16(op1, op2);
 
     CLOCK_CYCLES(18);
     PREFETCH_RUN(18, 2, rmdat, 1, 0, 0, 0, 1);
@@ -306,15 +270,13 @@ opIMUL_l_l_a16(uint32_t fetchdat)
     if (cpu_mod != 3)
         SEG_CHECK_READ(cpu_state.ea_seg);
 
-    temp64 = (int64_t) (int32_t) cpu_state.regs[cpu_reg].l * (int64_t) (int32_t) geteal();
+    int32_t op1 = cpu_state.regs[cpu_reg].l;
+    int32_t op2 = geteal();
     if (cpu_state.abrt)
         return 1;
+    temp64 = (int64_t) op1 * (int64_t) op2;
     cpu_state.regs[cpu_reg].l = temp64 & 0xFFFFFFFF;
-    flags_rebuild();
-    if ((temp64 >> 31) != 0 && (temp64 >> 31) != -1)
-        cpu_state.flags |= C_FLAG | V_FLAG;
-    else
-        cpu_state.flags &= ~(C_FLAG | V_FLAG);
+    setimul32(op1, op2);
 
     CLOCK_CYCLES(30);
     PREFETCH_RUN(30, 2, rmdat, 0, 1, 0, 0, 0);
@@ -329,15 +291,13 @@ opIMUL_l_l_a32(uint32_t fetchdat)
     if (cpu_mod != 3)
         SEG_CHECK_READ(cpu_state.ea_seg);
 
-    temp64 = (int64_t) (int32_t) cpu_state.regs[cpu_reg].l * (int64_t) (int32_t) geteal();
+    int32_t op1 = cpu_state.regs[cpu_reg].l;
+    int32_t op2 = geteal();
     if (cpu_state.abrt)
         return 1;
+    temp64 = (int64_t) op1 * (int64_t) op2;
     cpu_state.regs[cpu_reg].l = temp64 & 0xFFFFFFFF;
-    flags_rebuild();
-    if ((temp64 >> 31) != 0 && (temp64 >> 31) != -1)
-        cpu_state.flags |= C_FLAG | V_FLAG;
-    else
-        cpu_state.flags &= ~(C_FLAG | V_FLAG);
+    setimul32(op1, op2);
 
     CLOCK_CYCLES(30);
     PREFETCH_RUN(30, 2, rmdat, 0, 1, 0, 0, 1);


### PR DESCRIPTION
Summary
=======
This PR adds native JIT compilation support for `IMUL` (2 and 3-operand forms) and `XADD` (Exchange and Add) instructions in the new recompiler, replacing their previous interpreter fallback paths.

Key changes:
* **Native IMUL Compiler Support**: Adds `UOP_IMUL` and `UOP_IMUL_IMM` JIT micro-operations so they compile directly to native host instructions in both the x86-64 and ARM64 backends.
* **Lazy Flags for IMUL**: Integrates `FLAGS_IMUL16` and `FLAGS_IMUL32` to calculate the carry and overflow flags (CF/OF) lazily only when required.
* **JIT-compiling XADD**: Previously, `XADD` wasn't JIT-compiled at all and always forced a fallback to the interpreter. This implements native frontend compilation for `XADD` using existing JIT ALU primitives (`uop_ADD`, `uop_MOV`, etc.), keeping execution entirely inside JIT code blocks.

Checklist
=========
* [ ] Closes #xxx
* [x] I have tested my changes locally and validated that the functionality works as intended
* [ ] I have discussed this with core contributors already
* [ ] This pull request requires changes to the ROM set
  * [ ] I have opened a roms pull request - https://github.com/PCBox/roms/pull/changeme/
* [ ] This pull request requires changes to the asset set
  * [ ] I have opened an assets pull request - https://github.com/PCBox/assets/pull/changeme/

References
==========
* Intel® 64 and IA-32 Architectures Software Developer's Manual (IMUL and XADD Instruction References)
* ARM® Architecture Reference Manual ARMv8 (MUL and BFI Instruction References)